### PR TITLE
default.nix: Add check that hackage-db submodule is initialized

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,16 @@
 { pkgs ? import <nixpkgs> {} }:
 let
- hsPkgs = import ./pkgs.nix { inherit pkgs; };
+  hsPkgs = import ./pkgs.nix { inherit pkgs; };
 in
- hsPkgs // { nix-tools-all-execs = pkgs.symlinkJoin
-           { name = "nix-tools";
-             paths = builtins.attrValues hsPkgs.nix-tools.components.exes; }; }
+  if ! builtins.pathExists ./hackage-db/hackage-db.cabal
+  then abort ''
+
+    The `hackage-db' submodule is not initialized.
+    Run `git submodule update --init`.
+  ''
+  else
+    hsPkgs // {
+      nix-tools-all-execs = pkgs.symlinkJoin
+        { name = "nix-tools";
+          paths = builtins.attrValues hsPkgs.nix-tools.components.exes; };
+    }


### PR DESCRIPTION
Helps people like me who don't read the instructions carefully.
Otherwise the build error is really difficult.
