### PR TITLE
Better stack-to-nix support

### DIFF
--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -138,5 +138,8 @@ executable stack-to-nix
                      , hpack
                      , bytestring
                      , optparse-applicative
+                     , http-client-tls
+                     , http-client
+                     , http-types
   hs-source-dirs:      stack2nix
   default-language:    Haskell2010

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -15,14 +15,16 @@ let
                    (pkgs.fetchFromGitHub { owner  = "angerman";
                                            repo   = "hackage.nix";
                                            rev    = "66c28064da46525711722b75b4adb2ac878897d3";
-                                           sha256 = "12ffzzjgirwzha3ngxbniccgn19406iryxspq19kgi4kz9lz6bpr"; }))
+                                           sha256 = "12ffzzjgirwzha3ngxbniccgn19406iryxspq19kgi4kz9lz6bpr";
+                                           name   = "hackage-exprs-source"; }))
                    ;
   # a different haskell infrastructure
   haskell = import (overrideWith "haskell"
                     (pkgs.fetchFromGitHub { owner  = "angerman";
                                             repo   = "haskell.nix";
                                             rev    = "f2b80ee3efdcd5b1066f5aae9d02b3a4c02b22ad";
-                                            sha256 = "049fb4wxavrx4xs202aib2zxryd1d23dfls44argd29w90z5868h"; }))
+                                            sha256 = "049fb4wxavrx4xs202aib2zxryd1d23dfls44argd29w90z5868h";
+                                            name   = "haskell-lib-source"; }))
                    hackage;
 
   # our packages


### PR DESCRIPTION
stack-to-nix should generate a stack-pkgs.nix file now that that
can be used like this:

```
  stack-pkgs = import ./stack-pkgs.nix;

  pkgSet = haskell.mkNewPkgSet {
    inherit pkgs;
    pkg-def = stackage.${stack-pkgs.resolver};
    pkg-def-overlays = [ stack-pkgs.extra-deps ];
    modules = [
      (stack-pkgs.pkgs { inherit (pkgs) lib; })
    ];
  };
```

with the module system.