### PR TITLE
Adds truncate-index

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -3,7 +3,7 @@
 
 export NIX_PATH="nixpkgs=channel:nixos-19.03"
 index_state="2019-03-15T00:00:00Z"
-expected_hash="0ia8zj3la3r3nzyk96abvz2cfm6za9kdbap89v2k95njv34slx0b"
+expected_hash="1aq8y44g4f6r6nkjgyc853skca2x7k5wyphnd00vrpi7b062ydap"
 
 set -euo pipefail
 

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -46,7 +46,7 @@ nix build -f nix2 nix-tools.components.exes --no-link
 echo
 echo "--- Test index file truncation"
 
-nix-store --delete /nix/store/*-00-index.tar.gz || true
+find /nix/store/ -name "*-00-index.tar.gz" -exec nix-store --delete {} \;
 nix build -f test/truncate-index.nix --no-link \
     --arg nix-tools-path ./nix2  \
     --argstr index-state "$index_state" \

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -51,4 +51,4 @@ nix build -f test/truncate-index.nix --no-link \
     --arg nix-tools-path ./nix2  \
     --argstr index-state "$index_state" \
     --argstr hash "$expected_hash" \
-    -A indexTruncated
+    indexTruncated

--- a/nix-tools.cabal
+++ b/nix-tools.cabal
@@ -168,3 +168,16 @@ executable stack-to-nix
                      , http-types
   hs-source-dirs:      stack2nix
   default-language:    Haskell2010
+
+executable truncate-index
+  ghc-options:         -Wall
+  main-is:             Main.hs
+  -- other-modules:
+  build-depends:       base
+                     , optparse-applicative
+                     , zlib
+                     , tar
+                     , bytestring
+                     , time
+  hs-source-dirs:      truncate-index
+  default-language:    Haskell2010

--- a/test/truncate-index.nix
+++ b/test/truncate-index.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {}
+, nix-tools-path
+, index-state
+, hash
+}:
+
+rec {
+  hsPkgs = import nix-tools-path { inherit pkgs; };
+  index = builtins.fetchurl http://hackage.haskell.org/01-index.tar.gz;
+  indexTruncated = pkgs.runCommand "00-index.tar.gz" {
+    outputHashAlgo = "sha256";
+    outputHash = hash;
+  } ''
+    ${hsPkgs.nix-tools.components.exes.truncate-index}/bin/truncate-index -o $out -i ${index} -s ${index-state}
+  '';
+}

--- a/truncate-index/Main.hs
+++ b/truncate-index/Main.hs
@@ -1,0 +1,59 @@
+-- I am a sinner!
+{-# language RecordWildCards #-}
+
+module Main (main) where
+
+import Data.Maybe
+import Data.Time.Clock
+import Data.Time.Format
+import Data.Time.Clock.POSIX
+import Codec.Archive.Tar as Tar
+import Codec.Archive.Tar.Entry as Tar
+import Data.ByteString.Lazy as BS hiding (filter)
+import Codec.Compression.GZip as GZip
+
+import Options.Applicative hiding (option)
+import Data.Semigroup ((<>))
+
+-- | Parse a hackage index state like "2019-01-01T12:00:00Z"
+parseIndexState :: String -> Maybe UTCTime
+parseIndexState = parseTimeM True defaultTimeLocale (iso8601DateFormat (Just "%T%Z"))
+
+-- | Convert the standard 'UTCTime' type into the 'EpochTime' used by the @tar@
+-- library.
+toEpochTime :: UTCTime -> EpochTime
+toEpochTime = floor . utcTimeToPOSIXSeconds
+
+-- | Filter Haskell Index
+filterHaskellIndex :: FilePath -> String -> FilePath -> IO ()
+filterHaskellIndex orig indexState out =
+  BS.writeFile out . GZip.compress . Tar.write . f . Tar.read . GZip.decompress =<< BS.readFile orig
+  where f = filter ((<= ts) . Tar.entryTime) . toList
+        ts = toEpochTime . fromJust . parseIndexState $ indexState
+
+-- | Convert @Entries e@ to a list while throwing an error on failure.
+toList :: Show e => Entries e -> [Entry]
+toList (Next e es) = e:(toList es)
+toList Done = []
+toList (Fail e) = error (show e)
+
+--------------------------------------------------------------------------------
+-- CLI Argument
+data Args = Args
+  { argOutput :: FilePath
+  , argInput  :: FilePath
+  , argIndexState :: String
+  } deriving Show
+
+args :: Parser Args
+args = Args
+  <$> strOption ( long "output" <> short 'o' <> value "00-index.tar.gz" <> showDefault <> metavar "FILE" <> help "The output index" )
+  <*> strOption ( long "input" <> short 'i' <> value "01-index.tar.gz" <> showDefault <> metavar "FILE" <> help "The input index" )
+  <*> strOption ( long "indexState" <> short 's' <> metavar "INDEX" <> help "Index State ( YYYY-MM-DDTHH:MM:SSZ )" )
+
+main :: IO ()
+main = execParser opts >>= \Args{..} -> filterHaskellIndex argInput argIndexState argOutput
+  where opts = info (args <**> helper)
+          ( fullDesc
+         <> progDesc "Generate a truncated Hackage index"
+         <> header "truncate-index - a hackage index truncater" )


### PR DESCRIPTION
This tool allows us to truncate a hackage index into a 00-index.tar.gz
to be used with cabal.

```
$ curl -L -O http://hackage.haskell.org/01-index.tar.gz
$ truncate-index  -o 00-index.tar.gz -i 01-index.tar.gz \
  -s 2019-05-01T00:00:00Z
```

should produce the identical file each and every time.

We can then feed that into cabal using a custom local repository in
the ~/.cabal/config
```
repository local
  url: file:///path/to/00-index-tar-gz
  secure: False
```