### PR TITLE
Fix stack-to-nix: .stack-to-nix.cache: openFile: resource busy (file is locked)

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -17,7 +17,7 @@ cabal new-configure
 
 echo
 echo "+++ Run stable version of plan-to-nix"
-nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/hkm/use-source-repo.tar.gz") {}; in (import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs).haskell-nix.nix-tools.ghc8105)' -o nt
+nix build '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs).haskell-nix.nix-tools.ghc8105)' -o nt
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json
 
 # Replace currently broken plan-to-nix output

--- a/lib/Stack2nix/Cache.hs
+++ b/lib/Stack2nix/Cache.hs
@@ -4,7 +4,7 @@ module Stack2nix.Cache
   , cacheHits
   ) where
 
-import Control.Monad ((<$!>))
+import Control.DeepSeq ((<$!!>))
 import Control.Exception (catch, SomeException(..))
 
 readCache :: FilePath
@@ -15,7 +15,7 @@ readCache :: FilePath
                  , String -- pkgname
                  , String -- nixexpr-path
                  )]
-readCache f = fmap (toTuple . words) . lines <$!> readFile f
+readCache f = fmap (toTuple . words) . lines <$!!> readFile f
   where toTuple [ url, rev, subdir, sha256, pkgname, exprPath ]
           = ( url, rev, subdir, sha256, pkgname, exprPath )
 

--- a/lib/Stack2nix/Cache.hs
+++ b/lib/Stack2nix/Cache.hs
@@ -4,6 +4,7 @@ module Stack2nix.Cache
   , cacheHits
   ) where
 
+import Control.Monad ((<$!>))
 import Control.Exception (catch, SomeException(..))
 
 readCache :: FilePath
@@ -14,14 +15,13 @@ readCache :: FilePath
                  , String -- pkgname
                  , String -- nixexpr-path
                  )]
-readCache f = fmap (toTuple . words) . lines <$> readFile f
+readCache f = fmap (toTuple . words) . lines <$!> readFile f
   where toTuple [ url, rev, subdir, sha256, pkgname, exprPath ]
           = ( url, rev, subdir, sha256, pkgname, exprPath )
 
 appendCache :: FilePath -> String -> String -> String -> String -> String -> String -> IO ()
 appendCache f url rev subdir sha256 pkgname exprPath = do
-  appendFile f $ unwords [ url, rev, subdir, sha256, pkgname, exprPath ]
-  appendFile f "\n"
+  appendFile f $! unwords [ url, rev, subdir, sha256, pkgname, exprPath ] ++ "\n"
 
 cacheHits :: FilePath -> String -> String -> String -> IO [ (String, String) ]
 cacheHits f url rev subdir

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "920ac43ee13d95f56d7539bece1f5ee41b10c8a9",
-        "sha256": "0px60yvag24ayj9zl82cbnpixm41slj2wqw4p2vgbwnbz125hgsx",
+        "rev": "1992b910e9b4d880e1f4639f4fe7266bceb9a5ad",
+        "sha256": "15w3wixjnb52f7cj3s94fy0zc0l1gc94p3n2wyq3qqxj10hvirfw",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/920ac43ee13d95f56d7539bece1f5ee41b10c8a9.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/1992b910e9b4d880e1f4639f4fe7266bceb9a5ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
Error was seen here for example:
https://buildkite.com/input-output-hk/cardano-wallet/builds/12857#9be9bc9c-74ce-4b71-9827-d4f4c9baffc0/43-3704

But I don't know why we are now getting this after bumping Haskell.nix.