### PR TITLE
Change the way stack-to-nix outputs ghc options

### DIFF
--- a/lib/Stack2nix.hs
+++ b/lib/Stack2nix.hs
@@ -133,7 +133,7 @@ flags2nix pkgFlags =
 ghcOptions2nix :: GhcOptions -> [Binding NExpr]
 ghcOptions2nix ghcOptions =
   [ quoted pkgName $= mkNonRecSet
-    [ "package" $= mkNonRecSet [ "ghcOptions" $= mkStr opts ] ]
+    [ "ghcOptions" $= mkList [ mkStr opts ] ]
   | (pkgName, opts) <- HM.toList ghcOptions
   ]
 


### PR DESCRIPTION
This is needed for https://github.com/input-output-hk/haskell.nix/pull/1046