### PR TITLE
Add module setting `planned` to the output of `plan-to-nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,14 +4,12 @@ let
   sources = import ./nix/sources.nix {};
   haskellNix = import sources."haskell.nix" {};
   pkgs = import haskellNix.sources.nixpkgs-unstable haskellNix.nixpkgsArgs;
-  project = pkgs.haskell-nix.cabalProject {
+in
+  pkgs.haskell-nix.cabalProject {
     inherit compiler-nix-name;
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; name = "nix-tools"; };
-  };
-in
-  project // {
-    shell = project.shellFor {
-      tools = { cabal = "latest"; };
+    shell = {
+      tools.cabal = {};
       buildInputs = [
         pkgs.nix-prefetch-git
       ];

--- a/lib/Stack2nix.hs
+++ b/lib/Stack2nix.hs
@@ -89,7 +89,8 @@ stack2nix args (Stack resolver compiler pkgs pkgFlags ghcOpts) =
        , "resolver"  $= fromString (quoted resolver)
        , "modules" $= mkList [
            mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "packages" $= mkNonRecSet flags ]
-         , mkNonRecSet [ "packages" $= mkNonRecSet ghcOptions ] ]
+         , mkNonRecSet [ "packages" $= mkNonRecSet ghcOptions ]
+         , mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "planned" $= ("lib" @. "mkOverride" @@ mkInt 900 @@ mkBool True) ] ]
        ] ++ [
          "compiler" $= fromString (quoted c) | (Just c) <- [compiler]
        ]

--- a/lib/Stack2nix.hs
+++ b/lib/Stack2nix.hs
@@ -90,6 +90,7 @@ stack2nix args (Stack resolver compiler pkgs pkgFlags ghcOpts) =
        , "modules" $= mkList [
            mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "packages" $= mkNonRecSet flags ]
          , mkNonRecSet [ "packages" $= mkNonRecSet ghcOptions ]
+         -- Mark all packages as planned (stack projects do not have planned/unplanned components).
          , mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "planned" $= ("lib" @. "mkOverride" @@ mkInt 900 @@ mkBool True) ] ]
        ] ++ [
          "compiler" $= fromString (quoted c) | (Just c) <- [compiler]

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -261,7 +261,7 @@ value2plan plan = Plan { packages, components, extras, compilerVersion, compiler
                 (_, c)  -> map nixComponentAttr c)
       $ Vector.toList (plan ^. key "install-plan" . _Array)
 
-  -- Convert a cabal stile component name to the haskell.nix attribute path.
+  -- Convert a cabal style component name to the haskell.nix attribute path.
   componentNameToHaskellNixAttr :: Text -> String -> String
   componentNameToHaskellNixAttr pkgName n =
     case span (/=':') n of

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -10,6 +10,8 @@ import           Data.Aeson
 import           Data.Char                                ( isDigit )
 import           Data.HashMap.Strict                      ( HashMap )
 import qualified Data.HashMap.Strict           as Map
+import           Data.HashSet                             ( HashSet )
+import qualified Data.HashSet                  as Set
 import           Data.Maybe                               ( mapMaybe
                                                           , isJust
                                                           , fromMaybe
@@ -76,7 +78,7 @@ writeDoc file doc =
      hClose handle
 
 plan2nix :: Args -> Plan -> IO NExpr
-plan2nix args (Plan { packages, extras, compilerVersion, compilerPackages }) = do
+plan2nix args (Plan { packages, extras, components, compilerVersion, compilerPackages }) = do
   -- TODO: this is an aweful hack and expects plan-to-nix to be
   -- called from the toplevel project directory.
   cwd <- getCurrentDirectory
@@ -108,6 +110,7 @@ plan2nix args (Plan { packages, extras, compilerVersion, compilerPackages }) = d
   let flags = concatMap (\case
           (name, Just (Package _v _r f _)) -> flags2nix name f
           _ -> []) $ Map.toList extras
+      planned = map (\name -> name <> ".planned" $= ("lib" @. "mkOverride" @@ mkInt 900 @@ mkBool True)) $ Set.toList components
 
   return $ mkNonRecSet [
     "pkgs" $= ("hackage" ==> mkNonRecSet (
@@ -121,6 +124,7 @@ plan2nix args (Plan { packages, extras, compilerVersion, compilerPackages }) = d
     , "extras" $= ("hackage" ==> mkNonRecSet [ "packages" $= extrasNix ])
     , "modules" $= mkList [
         mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "packages" $= mkNonRecSet flags ]
+      , mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "packages" $= mkNonRecSet planned ]
       ]
     ]
  where
@@ -176,7 +180,7 @@ flags2nix pkgName pkgFlags =
   ]
 
 value2plan :: Value -> Plan
-value2plan plan = Plan { packages, extras, compilerVersion, compilerPackages }
+value2plan plan = Plan { packages, components, extras, compilerVersion, compilerPackages }
  where
   packages = fmap Just $ filterInstallPlan $ \pkg -> case ( pkg ^. key "type" . _String
                                               , pkg ^. key "style" . _String) of
@@ -239,7 +243,34 @@ value2plan plan = Plan { packages, extras, compilerVersion, compilerPackages }
       $ mapMaybe (\pkg -> (,) (pkg ^. key "pkg-name" . _String) <$> f pkg)
       $ Vector.toList (plan ^. key "install-plan" . _Array)
 
+  components :: HashSet Text
+  components =
+    Set.fromList
+      $ map (\pkg ->
+          quoted (pkg ^. key "pkg-name" . _String) <> ".components." <>
+            if pkg ^. key "type" . _String == "pre-existing"
+              then "library"
+              else Text.pack . componentNameToHaskellNixAttr (pkg ^. key "pkg-name" . _String) . Text.unpack $ pkg ^. key "component-name" . _String)
+      $ Vector.toList (plan ^. key "install-plan" . _Array)
 
+  componentNameToHaskellNixAttr :: Text -> String -> String
+  componentNameToHaskellNixAttr pkgName n =
+    case span (/=':') n of
+      -- Not sure why `plan.json` has both of these
+      ("", "")    -> "library"
+      ("lib", "") -> "library"
+      (prefix, ':':rest) -> componentPrefixToHaskellNix prefix <> "." <> quoted rest
+      _ -> error ("unknown component name format " <> show n <> " for package " <> show pkgName)
+
+  componentPrefixToHaskellNix :: String -> String
+  componentPrefixToHaskellNix "lib"   = "sublibs"
+  componentPrefixToHaskellNix "flib"  = "foreignlibs"
+  componentPrefixToHaskellNix "exe"   = "exes"
+  componentPrefixToHaskellNix "test"  = "tests"
+  componentPrefixToHaskellNix "bench" = "benchmarks"
+  componentPrefixToHaskellNix x = error ("unknown component prefix " <> x)
+
+defaultNixContents :: String
 defaultNixContents = unlines $
   [ "{ haskellNixSrc ? builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz"
   , ", haskellNix ? import haskellNixSrc {}"

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -247,11 +247,10 @@ value2plan plan = Plan { packages, components, extras, compilerVersion, compiler
   components =
     Set.fromList
       $ map (\pkg ->
-          quoted (pkg ^. key "pkg-name" . _String) <> 
+          quoted (pkg ^. key "pkg-name" . _String) <> ".components." <>
             if pkg ^. key "type" . _String == "pre-existing"
-              then ""
-              else ".components." <> (
-                Text.pack . componentNameToHaskellNixAttr (pkg ^. key "pkg-name" . _String) . Text.unpack $ pkg ^. key "component-name" . _String))
+              then "library"
+              else Text.pack . componentNameToHaskellNixAttr (pkg ^. key "pkg-name" . _String) . Text.unpack $ pkg ^. key "component-name" . _String)
       $ Vector.toList (plan ^. key "install-plan" . _Array)
 
   componentNameToHaskellNixAttr :: Text -> String -> String

--- a/plan2nix/Plan2Nix.hs
+++ b/plan2nix/Plan2Nix.hs
@@ -247,10 +247,11 @@ value2plan plan = Plan { packages, components, extras, compilerVersion, compiler
   components =
     Set.fromList
       $ map (\pkg ->
-          quoted (pkg ^. key "pkg-name" . _String) <> ".components." <>
+          quoted (pkg ^. key "pkg-name" . _String) <> 
             if pkg ^. key "type" . _String == "pre-existing"
-              then "library"
-              else Text.pack . componentNameToHaskellNixAttr (pkg ^. key "pkg-name" . _String) . Text.unpack $ pkg ^. key "component-name" . _String)
+              then ""
+              else ".components." <> (
+                Text.pack . componentNameToHaskellNixAttr (pkg ^. key "pkg-name" . _String) . Text.unpack $ pkg ^. key "component-name" . _String))
       $ Vector.toList (plan ^. key "install-plan" . _Array)
 
   componentNameToHaskellNixAttr :: Text -> String -> String

--- a/plan2nix/Plan2Nix/Plan.hs
+++ b/plan2nix/Plan2Nix/Plan.hs
@@ -14,6 +14,7 @@ module Plan2Nix.Plan
 
 import           Data.Text                                ( Text )
 import           Data.HashMap.Strict                      ( HashMap )
+import           Data.HashSet                             ( HashSet )
 
 type Version = Text
 type Revision = Text -- Can be: rNUM, cabal file sha256, or "default"
@@ -29,6 +30,7 @@ data Location
 data Plan = Plan
   { packages :: HashMap Text (Maybe Package)
   , extras :: HashMap Text (Maybe Package)
+  , components :: HashSet Text
   , compilerVersion :: Text
   , compilerPackages :: HashMap Text (Maybe Version)
   } deriving (Show)


### PR DESCRIPTION
So that we can avoid attempting to build components that were not in the `plan.json` file we need to identify those that were.  Changes `plan-to-nix` so it sets a `planned` option for all components in the `plan.json`.

For stack projects it marks everything as `planned`.