### PR TITLE
Fix union version ranges

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2022-02-02T00:00:00Z
+index-state: 2022-07-25T00:00:00Z
 
 packages: .
 
@@ -9,7 +9,3 @@ source-repository-package
     location: https://github.com/michaelpj/hackage-db.git
     tag: f3b9240212b036391871e4ea09891e91efcea7a1
     --sha256: sha256-n0ATmkwtR68E2FuZK3QIQgZirVmWbd21vIQmzhGKsRw=
-
--- hnix requires hnix-store-core < 0.2, however hnix-store-core-0.1 breaks
--- plan construction.
-allow-newer: hnix-store-core

--- a/lib/Cabal2Nix.hs
+++ b/lib/Cabal2Nix.hs
@@ -446,7 +446,7 @@ instance ToNixExpr (VersionRangeF VersionRange) where
   toNix (OrEarlierVersionF  ver) = (mkSym "compiler" @. "version") @. "le" @@ mkStr (fromString (show (pretty ver)))
   toNix (MajorBoundVersionF ver) = toNix (IntersectVersionRangesF (orLaterVersion ver) (earlierVersion (majorUpperBound ver)))
   toNix (IntersectVersionRangesF v1 v2) = toNix (projectVersionRange v1) $&& toNix (projectVersionRange v2)
-  toNix x = error $ "ToNixExpr VersionRange for `" ++ show x ++ "` not implemented!"
+  toNix (UnionVersionRangesF v1 v2) = toNix (projectVersionRange v1) $|| toNix (projectVersionRange v2)
 
 instance ToNixExpr a => ToNixExpr (Condition a) where
   toNix (Var a) = toNix a

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "aaae688f4700c788243e5c5508c5e17e0f8f50ab",
-        "sha256": "0b7ih529mfq72sfpmzix8r6zqgvqwcz0j9va9z9qm5gr3hb2y698",
+        "rev": "e3397e0ace4aeadefe941241bd5b7bfefad850a9",
+        "sha256": "0gllf109mpj6jlzh0nhgvxg2gq6gm8gbbh34fgbysjzz7j7l1ph0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/aaae688f4700c788243e5c5508c5e17e0f8f50ab.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e3397e0ace4aeadefe941241bd5b7bfefad850a9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
I think this should this issue from the hackage-to-nix daily updates
```
+ hackage-to-nix hackage.nix
--
  | hackage-to-nix: ToNixExpr VersionRange for `UnionVersionRangesF (UnionVersionRanges (ThisVersion (mkVersion [8,0,1])) (IntersectVersionRanges (OrLaterVersion (mkVersion [8,8])) (EarlierVersion (mkVersion [8,10,5])))) (ThisVersion (mkVersion [9,0,1]))` not implemented!
  | CallStack (from HasCallStack):
  | error, called at lib/Cabal2Nix.hs:449:13 in nix-tools-0.1.0.0-6K4QSsdwZNdCwcelxYdYpb:Cabal2Nix
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1

```